### PR TITLE
Add some IntelliJ generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,16 +40,29 @@ captures/
 
 # IntelliJ
 *.iml
+.idea/caches/
+.idea/libraries/
+.idea/shelf/
 .idea/workspace.xml
 .idea/tasks.xml
-.idea/gradle.xml
-.idea/assetWizardSettings.xml
-.idea/dictionaries
-.idea/libraries
-# Android Studio 3 in .gitignore file.
-.idea/caches
+.idea/.name
+.idea/compiler.xml
+.idea/copyright/profiles_settings.xml
+.idea/encodings.xml
+.idea/misc.xml
 .idea/modules.xml
-# Comment next line if keeping position of elements in Navigation Editor is relevant for you
+.idea/scopes/scope_settings.xml
+.idea/dictionaries
+.idea/vcs.xml
+.idea/jsLibraryMappings.xml
+.idea/datasources.xml
+.idea/dataSources.ids
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+.idea/assetWizardSettings.xml
+.idea/gradle.xml
+.idea/jarRepositories.xml
 .idea/navEditor.xml
 
 # Keystore files


### PR DESCRIPTION
I have JDK Temurin 17 installed instead of JDK 1.8 and `.idea/misc.xml` changes constantly. According to [this random website](https://gitignore.io) with the keyword 'AndroidStudio', these other files should also be ignored.